### PR TITLE
fix bug which will disarrange tags on iOS8

### DIFF
--- a/WrapViewWithAutolayout/SFTagView.m
+++ b/WrapViewWithAutolayout/SFTagView.m
@@ -124,7 +124,7 @@
 
     [self.subviews enumerateObjectsUsingBlock:^(SFTagButton *obj, NSUInteger idx, BOOL *stop) {
       if ([obj isKindOfClass:[SFTagButton class]]) {
-        if (obj.frame.origin.y == maxY) {
+        if (floor(obj.frame.origin.y) == floor(maxY)) {
           maxX = MAX(maxX, obj.frame.origin.x + obj.frame.size.width);
         }
       }


### PR DESCRIPTION
将直接比较两个浮点数改成去掉小数部分变成整数再比较是否相等。这个bug在iOS9上没有，iOS8中会导致tag的排列错乱
